### PR TITLE
[fix/#29] 문서 공유 에러 핸들링 추가

### DIFF
--- a/docs/views.py
+++ b/docs/views.py
@@ -117,7 +117,9 @@ OPGC 프로젝트는 다음과 같은 기능을 제공합니다.
 def docs_share(request):
     if request.method == 'POST':
         docs_id = request.data.get('docs_id')
-        print(docs_id)
+        if docs_id is None:
+            return Response({"message": "문서 ID를 입력해주세요", "status": 400}, status=status.HTTP_400_BAD_REQUEST)
+
         doc = Docs.objects.get(pk=docs_id)
         print(doc)
         if doc.url is not None:


### PR DESCRIPTION
## 📢 기능 설명

<img width="363" alt="image" src="https://github.com/2023WB-TeamB/Backend/assets/144754093/7028f204-dd47-42b9-ace5-b906697bf5bc">
<br>
docs_id가 null인 경우 400 에러를 반환하도록 수정
<br>

## 연결된 issue

연결된 issue를 자동을 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #29 
<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 이슈넘버를 적었는가?
