### PR TITLE
[fix/#32] 문서 공유 에러 핸들링 추가

### DIFF
--- a/docs/views.py
+++ b/docs/views.py
@@ -117,13 +117,17 @@ OPGC 프로젝트는 다음과 같은 기능을 제공합니다.
 def docs_share(request):
     if request.method == 'POST':
         docs_id = request.data.get('docs_id')
-        if docs_id is None:
-            return Response({"message": "문서 ID를 입력해주세요", "status": 400}, status=status.HTTP_400_BAD_REQUEST)
 
-        doc = Docs.objects.get(pk=docs_id)
-        print(doc)
+        if docs_id is None:
+            return Response({"message": "문서 ID를 입력해 주세요.", "status": 400}, status=status.HTTP_400_BAD_REQUEST)
+
+        try:
+            doc = Docs.objects.get(pk=docs_id)
+        except Docs.DoesNotExist:
+            return Response({"message": "존재하지 않는 문서 ID입니다.", "status": 404}, status=status.HTTP_404_NOT_FOUND)
+
         if doc.url is not None:
-            return Response({"message": "이미 URL이 생성된 문서입니다", "status": 409}, status=status.HTTP_409_CONFLICT)
+            return Response({"message": "이미 URL이 생성된 문서입니다.", "status": 409}, status=status.HTTP_409_CONFLICT)
 
         # UUID를 사용하여 고유한 URL 생성
         base_url = 'http://127.0.0.1:8000/api/v1/docs/share/'


### PR DESCRIPTION
## 📢 기능 설명

<img width="361" alt="image" src="https://github.com/2023WB-TeamB/Backend/assets/144754093/5229640b-2d70-4e5a-884d-9e39097ce21d">
<br>
존재하지 않는 docs_id를 입력할 시에 404 에러를 반환하도록 수정
<br>

## 연결된 issue

연결된 issue를 자동을 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #32 
<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 이슈넘버를 적었는가?
