### PR TITLE
[fix/#34] 문서 생성 API 에러 핸들링 및 Request Body 형식 수정

### DIFF
--- a/docs/views.py
+++ b/docs/views.py
@@ -33,6 +33,12 @@ class DocsDetail(APIView): # Docs의 detail을 보여주는 역할
 def docs_create(request):
 
     if request.method == 'POST':
+        language = request.data['language']
+        repository_url = request.data['repository_url']
+
+        if language is None or repository_url is None:
+            return Response({"message": "잘못된 요청입니다. 입력 형식을 확인해 주세요.", "status": 400}, status=status.HTTP_400_BAD_REQUEST)
+
         request.data['user_id'] = User.objects.filter(id=1).first().id
         request.data['title'] = "OPGC (Open Source Project's Github Contributions)"
         request.data['content'] = """## 프로젝트 소개
@@ -105,7 +111,6 @@ OPGC 프로젝트는 다음과 같은 기능을 제공합니다.
 각 앱은 자체적인 모델과 API를 구성하고 있으며, 기능별로 분리되어 관리되고 있습니다.
 
 위와 같은 기능들은 Django REST framework를 사용하여 구현되었으며, 캐싱을 위해 cacheops를, 에러 로깅을 위해 sentry-sdk를 사용하고 있습니다. 또한, front-end와 연계하여 쉽게 사용할 수 있도록 API를 제공하고 있습니다."""
-        request.data['language'] = 'KOR'
 
         serializer = DocsSerializer(data=request.data)
         if serializer.is_valid():

--- a/docs/views.py
+++ b/docs/views.py
@@ -33,10 +33,10 @@ class DocsDetail(APIView): # Docs의 detail을 보여주는 역할
 def docs_create(request):
 
     if request.method == 'POST':
-        language = request.data['language']
-        repository_url = request.data['repository_url']
+        repository_url = request.data.get('repository_url')
+        language = request.data.get('language')
 
-        if language is None or repository_url is None:
+        if repository_url is None or language is None or language not in ['KOR', 'ENG']:
             return Response({"message": "잘못된 요청입니다. 입력 형식을 확인해 주세요.", "status": 400}, status=status.HTTP_400_BAD_REQUEST)
 
         request.data['user_id'] = User.objects.filter(id=1).first().id


### PR DESCRIPTION
## 📢 기능 설명
1. 기존 문서 생성 API에서 형식이 잘못된 경우 500에러를 반환했는데,
API 명세에 맞게 400에러와 함께 반환하도록 추가 구현

2. Request Body 형식 변경
<img width="603" alt="Screenshot 2024-01-09 at 9 19 38 PM" src="https://github.com/2023WB-TeamB/Backend/assets/107194331/e40c30e0-2703-4d07-9750-aadfe36bb549">

필요시 실행결과 스크린샷 첨부
### language 형식을 잘못 입력한 경우
<img width="813" alt="Screenshot 2024-01-09 at 9 20 01 PM" src="https://github.com/2023WB-TeamB/Backend/assets/107194331/002a15ce-7b55-4198-98ec-70b1284897ab">

### Request Body 형식과 다르게 보낼 경우
<img width="594" alt="Screenshot 2024-01-09 at 9 20 56 PM" src="https://github.com/2023WB-TeamB/Backend/assets/107194331/a72e98eb-e81d-4c48-a616-2b45fa3f364e">

<br>

## 연결된 issue

연결된 issue를 자동을 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #34 
<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 이슈넘버를 적었는가?
