### PR TITLE
[Fix/#102] 문서 검색 API 메소드 변경

### DIFF
--- a/docs/views.py
+++ b/docs/views.py
@@ -375,7 +375,7 @@ class DocsContributorView(APIView):
 class DocsSearchView(APIView):
     permission_classes = [IsAuthenticated]
 
-    @swagger_auto_schema(tags=["Docs"], operation_summary="문서 검색 API", manual_parameters=[openapi.Parameter('query', openapi.IN_QUERY, description="검색어", type=openapi.TYPE_STRING, required=True)])
+    @swagger_auto_schema(tags=["Docs"], operation_summary="문서 검색 API", request_body=SwaggerDocsSearchPostSerializer)
     def get(self, request, *args, **kwargs):
         authorization_header = request.META.get('HTTP_AUTHORIZATION')
         if authorization_header and authorization_header.startswith('Bearer '):

--- a/docs/views.py
+++ b/docs/views.py
@@ -2,6 +2,7 @@ import time
 from collections import defaultdict
 
 from django.core.exceptions import ObjectDoesNotExist
+from drf_yasg import openapi
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.views import APIView
 
@@ -374,8 +375,8 @@ class DocsContributorView(APIView):
 class DocsSearchView(APIView):
     permission_classes = [IsAuthenticated]
 
-    @swagger_auto_schema(tags=["Docs"], operation_summary="문서 검색 API", request_body=SwaggerDocsSearchPostSerializer)
-    def post(self, request, *args, **kwargs):
+    @swagger_auto_schema(tags=["Docs"], operation_summary="문서 검색 API", manual_parameters=[openapi.Parameter('query', openapi.IN_QUERY, description="검색어", type=openapi.TYPE_STRING, required=True)])
+    def get(self, request, *args, **kwargs):
         authorization_header = request.META.get('HTTP_AUTHORIZATION')
         if authorization_header and authorization_header.startswith('Bearer '):
             token = authorization_header.split(' ')[1]
@@ -383,7 +384,7 @@ class DocsSearchView(APIView):
         else:
             return Response(status=status.HTTP_401_UNAUTHORIZED)
 
-        query = request.data.get('query')
+        query = request.GET.get('query')
         if query is None:
             return Response({"message": "검색어를 입력해 주세요.", "status": 400}, status=status.HTTP_400_BAD_REQUEST)
 
@@ -397,3 +398,4 @@ class DocsSearchView(APIView):
             "status": 200,
             "data": serializer.data
         }, status=status.HTTP_200_OK)
+


### PR DESCRIPTION
## 📢 기능 설명
<img width="980" alt="image" src="https://github.com/2023WB-TeamB/Backend/assets/144754093/b42cc23b-0177-4803-a288-501e748effcc">
메소드 POST -> GET으로 변경
<br>

## 연결된 issue

연결된 issue를 자동을 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #102 
<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 이슈넘버를 적었는가?
