### PR TITLE
[Refactor] terminal 1뱃지 사이즈 조정

### DIFF
--- a/templates/tag/terminal1.html
+++ b/templates/tag/terminal1.html
@@ -150,12 +150,12 @@
 
             .rank-abc {
                 position: absolute;
-                font-family: DNFBitBitv2;
+                font-family: "Andale Mono";
                 color: white;
                 font-size: 120px;
                 font-style: italic;
-                right: 180px;
-                top: 105px;
+                right: 187px;
+                top: 124px;
             }
 
             @keyframes fillup {

--- a/templates/tag/terminal1.html
+++ b/templates/tag/terminal1.html
@@ -6,12 +6,12 @@
      xmlns:xlink="http://www.w3.org/1999/xlink"
      x="0px"
      y="0px"
-     width="957px"
-     height="367px"
+     width="450px"
+     height="200px"
      enable-background="new 0 0 455 429"
      xml:space="preserve"
 >
-<foreignObject width="957px" height="367px">
+<foreignObject width="450px" height="200px">
     <div xmlns="http://www.w3.org/1999/xhtml">
             <meta charset="utf-8"/>
         <style>
@@ -50,8 +50,8 @@
                 align-items: flex-start;
                 padding: 0;
                 margin: 0;
-                width: 957px;
-                height: 367px;
+                width: 450px;
+                height: 200px;
 
                 border-radius: 43px;
                 background: #323232;
@@ -63,11 +63,11 @@
                 align-items: center;
                 padding: 0;
                 margin: 0;
-                height: 68px;
+                height: 38px;
                 background: transparent;
             }
             .name-tag-left {
-                height: 68px;
+                height: 38px;
                 border-radius: 43px 0 0 0;
                 background: #1C67D7;
 
@@ -78,7 +78,7 @@
             }
 
             .repo-tag-left {
-                height: 68px;
+                height: 38px;
                 {#border-radius: 43px 0 0 0;#}
                 background: #2CB86C;
 
@@ -87,13 +87,14 @@
                 align-items: center;
                 justify-content: center;
                 transform: translateX(-39px);
+                margin-left: 10px;
             }
 
             .tag-text {
                 color: #FFF;
                 text-align: center;
                 font-family: "Andale Mono";
-                font-size: 30px;
+                font-size: 15px;
                 font-style: normal;
                 font-weight: 400;
                 line-height: normal;
@@ -105,12 +106,12 @@
                 color: #FFF;
                 text-align: center;
                 font-family: "Andale Mono";
-                font-size: 30px;
+                font-size: 15px;
                 font-style: normal;
                 font-weight: 400;
                 line-height: normal;
 
-                margin-left: 70px;
+                margin-left: 60px;
                 margin-right: 20px;
             }
 
@@ -127,11 +128,11 @@
 
             .info {
                 font-family: "Andale Mono";
-                font-size: 35px;
+                font-size: 18px;
                 color: #FFFFFF;
 
-                margin-left: 79px;
-                margin-top: 49px;
+                margin-left: 40px;
+                margin-top: 30px;
             }
 
             .position, .commits, .pull-request, .contribution {
@@ -139,23 +140,24 @@
             }
 
             .rank {
-                width: 258px;
-                height: 258px;
+                width: 120px;
+                height: 120px;
                 {#margin-left: 106px;#}
                 display: flex;
                 justify-content: flex-start;
                 align-items: flex-start;
-                padding-right: 90px;
+                padding-right: 15px;
+                padding-top: 15px;
             }
 
             .rank-abc {
                 position: absolute;
                 font-family: "Andale Mono";
                 color: white;
-                font-size: 120px;
+                font-size: 50px;
                 font-style: italic;
-                right: 187px;
-                top: 124px;
+                right: 62px;
+                top: 83px;
             }
 
             @keyframes fillup {
@@ -192,12 +194,12 @@
                 <div class="name-tag-left">
                     <div class="tag-text">{{ github_user }}</div>
                 </div>
-                <img style="z-index: 1" alt="" src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMzkiIGhlaWdodD0iNjgiIHZpZXdCb3g9IjAgMCAzOSA2OCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik0wIDBWNjhMMzkgMzRMMCAwWiIgZmlsbD0iIzFDNjdENyIvPgo8L3N2Zz4K" />
+                <img style="z-index: 1" alt="" src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMzAiIGhlaWdodD0iMzgiIHZpZXdCb3g9IjAgMCAzMCAzOCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik0wIDBWMzhMMzAgMTlMMCAwWiIgZmlsbD0iIzFDNjdENyIvPgo8L3N2Zz4K" />
 
                 <div class="repo-tag-left">
                     <div class="repo-tag-text">{{ repo_name }}</div>
                 </div>
-                <img style="transform: translateX(-39px);" alt="" src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMzkiIGhlaWdodD0iNjgiIHZpZXdCb3g9IjAgMCAzOSA2OCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik0wIDBWNjhMMzkgMzRMMCAwWiIgZmlsbD0iIzJDQjg2QyIvPgo8L3N2Zz4K" />
+                <img style="transform: translateX(-39px);" alt="" src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMzAiIGhlaWdodD0iMzgiIHZpZXdCb3g9IjAgMCAzMCAzOCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik0wIDBWMzhMMzAgMTlMMCAwWiIgZmlsbD0iIzJDQjg2QyIvPgo8L3N2Zz4K" />
             </div>
 
             <div class="info-group">


### PR DESCRIPTION
## 📢 기능 설명
terminal1 badge size -> 450 px * 200 px 조정

필요시 실행결과 스크린샷 첨부
<br>
<img width="909" alt="image" src="https://github.com/2023WB-TeamB/Backend/assets/83015089/488e41da-a36e-46b4-886d-89384e7af46b">


## 연결된 issue

연결된 issue를 자동을 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #126 
<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 이슈넘버를 적었는가?
