### PR TITLE
[fix/#140] 공유 문서 조회 API response data 수정

### DIFF
--- a/docs/serializers.py
+++ b/docs/serializers.py
@@ -10,6 +10,12 @@ class KeywordsSerializer(serializers.ModelSerializer):
         model = Keywords
         fields = ['name']
 
+class DocsShareSerializer(serializers.ModelSerializer):
+    keywords = KeywordsSerializer(source='keywords_set', many=True)
+
+    class Meta:
+        model = Docs
+        fields = ['id', 'title', 'content', 'keywords', 'repository_url', 'url', 'language', 'created_at', 'updated_at', 'color']
 
 class DocsSearchSerializer(serializers.ModelSerializer):
     keywords = KeywordsSerializer(source='keywords_set', many=True)

--- a/docs/views.py
+++ b/docs/views.py
@@ -490,7 +490,7 @@ class DocsShareView(APIView):
         except Docs.DoesNotExist:
             return Response({"message": "존재하지 않는 UUID입니다.", "status": 404}, status=status.HTTP_404_NOT_FOUND)
 
-        serializer = DocsSerializer(doc)
+        serializer = DocsShareSerializer(doc)
 
         return Response({
             "message": "공유 문서 조회 성공",


### PR DESCRIPTION
## 📢 기능 설명
공유 문서 조회 API response data에 keyword 추가<br>
<img width="1013" alt="image" src="https://github.com/2023WB-TeamB/Backend/assets/144754093/7d24b1aa-59c8-4fba-ab05-883ac4801468">
<br>

## 연결된 issue

연결된 issue를 자동을 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #140 
<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
