### PR TITLE
[fix/#150] 문서 공유 url 형식 수정

### DIFF
--- a/docs/views.py
+++ b/docs/views.py
@@ -421,7 +421,7 @@ class DocsShareView(APIView):
             return Response({"message": "이미 URL이 생성된 문서입니다.", "status": 409, "existing_url": doc.url},
                             status=status.HTTP_409_CONFLICT)
         # UID를 사용하여 고유한 URL 생성
-        base_url = 'https://gitodoc.kro.kr/api/v1/docs/share/'
+        base_url = 'https://gitodoc.kro.kr/share/'
         unique_url = base_url + str(uuid.uuid4())
         self.generated_uuid = str(uuid.uuid4())
         unique_url = base_url + self.generated_uuid


### PR DESCRIPTION
## 📢 기능 설명

문서 공유 url 형식 https://gitodoc.kro.kr/share/{uuid}로 수정
<br>

## 연결된 issue

연결된 issue를 자동을 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #150 
<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
